### PR TITLE
Allow passing of options to include in svg tag

### DIFF
--- a/lib/initials/svg.rb
+++ b/lib/initials/svg.rb
@@ -4,12 +4,13 @@ module Initials
 
     attr_reader :name, :colors, :limit, :shape, :size
 
-    def initialize(name, colors: 12, limit: 3, shape: :circle, size: 32)
+    def initialize(name, colors: 12, limit: 3, shape: :circle, size: 32, tag_options: {})
       @name = name.to_s.strip
       @colors = colors
       @limit = limit
       @shape = shape
       @size = size
+      @tag_options = tag_options
 
       raise Initials::Error.new("Colors must be a divider of 360 e.g. 24 but not 16.") unless valid_colors?
       raise Initials::Error.new("Size is not a positive integer.") unless valid_size?
@@ -21,7 +22,7 @@ module Initials
 
     def to_s
       svg = [
-        "<svg xmlns='http://www.w3.org/2000/svg' width='#{size}' height='#{size}'>",
+        "<svg xmlns='http://www.w3.org/2000/svg' width='#{size}' height='#{size}' #{parsed_tag_options}>",
           shape == :rect ?
             "<rect width='#{size}' height='#{size}' rx='#{size / 32}' ry='#{size / 32}' fill='#{fill}' />"
           :
@@ -56,6 +57,10 @@ module Initials
 
     def initials
       name.split(' ')[0, limit].map { |s| s[0].capitalize }.join
+    end
+
+    def parsed_tag_options
+      @tag_options.map { |k, v| "#{k.to_s}='#{v}'" }.join(" ")
     end
 
     private

--- a/spec/svg_spec.rb
+++ b/spec/svg_spec.rb
@@ -84,8 +84,14 @@ RSpec.describe Initials::SVG do
     end
 
     describe "svg tag" do
+      let(:options) { {tag_options: {css: "class1 class2", "aria-label": "This is a label"}} }
+
       it "has valid xmlns attribute" do
         expect(subject.to_s).to match(/^<svg xmlns='http:\/\/www.w3.org\/2000\/svg'.+<\/svg>/)
+      end
+
+      it "has tags and values passed as options" do
+        expect(rick.to_s).to match(/ css='class1 class2' aria-label='This is a label'/)
       end
     end
 


### PR DESCRIPTION
So you can do something like this:

```
Initials.svg(user_name, limit: 2, tag_options: {css: "class1 class2", "aria-label": "This is a label"})
```

And get those options back on the `svg` tag like `css='class1 class2' aria-label='This is a label'`.